### PR TITLE
Fix scrolling to top for IE versions

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -25,8 +25,10 @@ export default class WorldIfApp extends React.Component {
   }
 
   scrollToTop() {
-    const body = window.document.body;
-    body.scrollTop = 0;
+    if (typeof window !== 'undefined' && window.document) {
+      const body = window.document.documentElement || window.document.body;
+      body.scrollTop = 0;
+    }
   }
 
   render() {


### PR DESCRIPTION
This fixes IE9 & co which dont scroll to top on page transition - because `document.body.scrollTop` is not the right element to target in IE9. Instead we need to target `document.documentElement.scrollTop`. (See https://stackoverflow.com/questions/2717252/document-body-scrolltop-is-always-0-in-ie-even-when-scrolling for more).

