### PR TITLE
Fixed scroll to top CrossBrowser

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -26,8 +26,7 @@ export default class WorldIfApp extends React.Component {
 
   scrollToTop() {
     if (typeof window !== 'undefined' && window.document) {
-      const body = window.document.documentElement || window.document.body;
-      body.scrollTop = 0;
+      window.scrollTo(0, 0);
     }
   }
 


### PR DESCRIPTION
This fix is meant to create a CrossBrowser scroll to top functionality.

Tested on IE9+, Chrome, Safari, FF